### PR TITLE
version fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/mapbox-events-ios",
-  "version": "0.7.0",
+  "version": "0.10.2",
   "description": "Telemetry and Location Services",
   "keywords": [
     "mapbox",


### PR DESCRIPTION
iosでmapboxmobileeventが起動時にクラッシュするので新バージョンは安定していない。
旧バージョンを使うがpackage.jsonの情報が正しくないので修正